### PR TITLE
Update the delay functions to use 64-bit values. 

### DIFF
--- a/hardware/freedom_e/cores/arduino/wiring.h
+++ b/hardware/freedom_e/cores/arduino/wiring.h
@@ -42,33 +42,26 @@ extern const volatile void* variant_pwm[];
 extern const uint32_t variant_pwm_size;
 
 /**
- * \brief Returns the number of milliseconds since the Arduino board began running the current program.
+ * \brief Returns the number of milliseconds since the board began running the current program.
  *
- * This number will overflow (go back to zero), after approximately 50 days.
- *
- * \return Number of milliseconds since the program started (uint32_t)
+ * \return Number of milliseconds since the program started (uint64_t)
  */
-extern uint32_t millis( void ) ;
+extern uint64_t millis( void ) ;
 
 /**
- * \brief Returns the number of microseconds since the Arduino board began running the current program.
- *
- * This number will overflow (go back to zero), after approximately 70 minutes. On 16 MHz Arduino boards
- * (e.g. Duemilanove and Nano), this function has a resolution of four microseconds (i.e. the value returned is
- * always a multiple of four). On 8 MHz Arduino boards (e.g. the LilyPad), this function has a resolution
- * of eight microseconds.
+ * \brief Returns the number of microseconds since the board began running the current program.
  *
  * \note There are 1,000 microseconds in a millisecond and 1,000,000 microseconds in a second.
  */
-extern uint32_t micros( void ) ;
+extern uint64_t micros( void ) ;
 
 /**
  * \brief Pauses the program for the amount of time (in miliseconds) specified as parameter.
  * (There are 1000 milliseconds in a second.)
  *
- * \param dwMs the number of milliseconds to pause (uint32_t)
+ * \param dwMs the number of milliseconds to pause (uint64_t)
  */
-extern void delay( uint32_t dwMs ) ;
+extern void delay( uint64_t dwMs ) ;
 
 /**
  * \brief Pauses the program for the amount of time (in microseconds) specified as parameter.
@@ -78,11 +71,14 @@ extern void delay( uint32_t dwMs ) ;
 
 static inline void delayMicroseconds(uint32_t) __attribute__((always_inline, unused));
 static inline void delayMicroseconds(uint32_t usec){
-    if (usec == 0) return;
-    int32_t endwait = micros() + usec;
-    while( ((int32_t)micros())-endwait < 0);
+  // This could be tuned to be more precise for short delays.
+  if (usec == 0) {
+    return;
+  }
+  uint64_t endwait = micros() + usec;
+  while(micros() < endwait){
+  }
 }
-
 __END_DECLS
 
 #endif /* _WIRING_ */


### PR DESCRIPTION
This is consistent with more recent versions of Arduino.h, which use 'unsigned long'.

It bugs me a little that there could still be a glitch if you read mcycle and mcycleh right at a rollover. This is a generic problem. 