### PR TITLE
Adding missing __enable_irq and __disable_irq

### DIFF
--- a/hardware/freedom_e/cores/arduino/wiring_constants.h
+++ b/hardware/freedom_e/cores/arduino/wiring_constants.h
@@ -19,6 +19,8 @@
 #ifndef _WIRING_CONSTANTS_
 #define _WIRING_CONSTANTS_
 
+#include <sys/isr.h>
+
 __BEGIN_DECLS
 
 #define HIGH 0x1


### PR DESCRIPTION
The interrupt handling functions are defined in the sys/isr.h, but this isn't included here and that fails with compiler errors when it is used. Including it here solves the problem.